### PR TITLE
Add default: 'now' for datetime fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 - Identifier schema is not a Registry, it's a regular entity
+- Add default: `now` for datetime fields
 
 ## [1.0.3][] - 2021-06-30
 

--- a/schemas/Cursor.js
+++ b/schemas/Cursor.js
@@ -3,7 +3,7 @@
 
   session: 'Session',
   hashsum: 'string',
-  created: 'datetime',
+  created: { type: 'datetime', default: 'now' },
   query: 'json',
   version: { type: 'number', default: 0 },
 });

--- a/schemas/File.js
+++ b/schemas/File.js
@@ -8,7 +8,7 @@
   mediaType: 'string',
 
   access: {
-    last: 'datetime',
+    last: { type: 'datetime', default: 'now' },
     count: { type: 'number', default: 0 },
   },
 

--- a/schemas/Identifier.js
+++ b/schemas/Identifier.js
@@ -2,11 +2,19 @@
   Entity: {},
 
   category: '?Identifier',
-  storage: { enum: ['master', 'cache', 'backup', 'replica'], index: true },
-  status: { enum: ['prealloc', 'init', 'actual', 'historical'], index: true },
-  creation: 'datetime',
-  change: 'datetime',
+  storage: {
+    enum: ['master', 'cache', 'backup', 'replica'],
+    default: 'master',
+    index: true,
+  },
+  status: {
+    enum: ['prealloc', 'init', 'actual', 'historical'],
+    default: 'actual',
+    index: true,
+  },
+  creation: { type: 'datetime', default: 'now' },
+  change: { type: 'datetime', default: 'now' },
   lock: { type: 'boolean', default: false },
   version: { type: 'number', default: 0 },
-  hashsum: 'string',
+  hashsum: { type: 'string', default: '' },
 });

--- a/schemas/Journal.js
+++ b/schemas/Journal.js
@@ -5,7 +5,7 @@
   account: 'Account',
   server: 'Server',
   action: 'string',
-  dateTime: 'datetime',
+  dateTime: { type: 'datetime', default: 'now' },
   ip: 'ip',
   details: 'json',
 });


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
