### PR TITLE
Use relative path to load schemas from node_modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Use relative path to load schemas from node_modules
+
 ## [1.0.4][] - 2021-08-02
 
 - Identifier schema is not a Registry, it's a regular entity

--- a/metadomain.js
+++ b/metadomain.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { Model } = require('metaschema');
 
 const load = async () => {
-  const modelPath = path.join(process.cwd(), 'schemas');
+  const modelPath = path.join(__dirname, 'schemas');
   return Model.load(modelPath);
 };
 


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
